### PR TITLE
Add rfspec plugin: multi-model spec generation

### DIFF
--- a/.factory-plugin/marketplace.json
+++ b/.factory-plugin/marketplace.json
@@ -23,6 +23,12 @@
       "description": "Core Skills for essential functionalities and integrations",
       "source": "./plugins/core",
       "category": "core"
+    },
+    {
+      "name": "rfspec",
+      "description": "Request for Spec: fan out a prompt to multiple AI models in parallel and pick or synthesize the best implementation spec",
+      "source": "./plugins/rfspec",
+      "category": "productivity"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -48,6 +48,14 @@ Skills for continuous learning and improvement.
 - `frontend-design` - Build web apps, websites, HTML pages with good design
 - `browser-navigation` - Browser automation with agent-browser
 
+### rfspec
+
+Request for Spec -- fan out a prompt to multiple AI models in parallel and pick or synthesize the best implementation spec.
+
+**Commands:**
+
+- `/rfspec` - Send a prompt to Opus 4.6, GPT-5.4, and Gemini 3.1 Pro simultaneously, compare the resulting specs, and choose or synthesize the best one
+
 ## Plugin Structure
 
 Each plugin follows the Factory plugin format:

--- a/plugins/rfspec/.factory-plugin/plugin.json
+++ b/plugins/rfspec/.factory-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "rfspec",
+  "description": "Request for Spec: fan out a prompt to multiple AI models in parallel and pick or synthesize the best implementation spec",
+  "version": "1.0.0",
+  "author": {
+    "name": "Andy Taylor",
+    "email": "andrew.taylor@factory.ai"
+  }
+}

--- a/plugins/rfspec/README.md
+++ b/plugins/rfspec/README.md
@@ -1,0 +1,46 @@
+# rfspec
+
+Request for Spec -- fan out a prompt to multiple AI models in parallel and choose or synthesize the best implementation spec.
+
+## What it does
+
+`/rfspec` sends your prompt to three models simultaneously (Claude Opus 4.6, GPT-5.4, Gemini 3.1 Pro), each generating a structured implementation spec. The results are presented side-by-side so you can pick the strongest one or synthesize a combination.
+
+## Usage
+
+```
+/rfspec <describe what you want to build>
+```
+
+Example:
+
+```
+/rfspec add a dark mode toggle to the settings page with persistent user preference
+```
+
+The command will:
+
+1. Send the prompt to all three models in parallel via `droid exec`
+2. Collect and display each model's spec (Options A, B, C)
+3. Ask you to pick one as-is or synthesize the best parts into a final spec
+4. Save the chosen spec to `specs/active/YYYY-MM-DD-<slug>.md`
+
+## Requirements
+
+- **droid CLI** -- must be installed and authenticated
+- **jq** -- for JSON parsing (`brew install jq` on macOS)
+- Access to at least one of the three models. Models that fail are skipped gracefully; the command only errors if all three fail.
+
+## Spec skeleton
+
+Every generated spec follows a consistent structure:
+
+- Purpose / Big Picture
+- Context and Orientation
+- Plan of Work (with named files and concrete steps)
+- Progress checklist
+- Validation and Acceptance criteria
+- Key Decisions table
+- Risks & Mitigations
+- Surprises & Discoveries
+- Outcomes & Retrospective

--- a/plugins/rfspec/commands/rfspec
+++ b/plugins/rfspec/commands/rfspec
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ── guard: dependencies ──────────────────────────────────────────────
+command -v jq  >/dev/null 2>&1 || { echo "Error: jq is required but not installed. Install it with: brew install jq"; exit 1; }
+command -v droid >/dev/null 2>&1 || { echo "Error: droid CLI is required but not found on PATH."; exit 1; }
+
+PROMPT="$*"
+
+if [ -z "$PROMPT" ]; then
+  echo "Usage: /rfspec <your prompt>"
+  echo ""
+  echo "Sends your prompt to three models in parallel (Opus, GPT, Gemini),"
+  echo "then lets you pick the best spec or synthesize a combination."
+  exit 1
+fi
+
+# ── spec skeleton ────────────────────────────────────────────────────
+SKELETON='# [Short, action-oriented title]
+
+This spec is a living document.
+
+## Purpose / Big Picture
+
+[Why the work matters. What someone can do after that they couldn'\''t before.]
+
+## Context and Orientation
+
+[Current state relevant to this task. Key files, modules, terms defined.
+Name files by full path when possible.]
+
+## Plan of Work
+
+[Numbered sequence of edits and additions. For each step, name the file,
+location, and what to change. Keep it concrete.]
+
+## Progress
+
+- [ ] [Step 1 -- derived from Plan of Work]
+- [ ] [Step 2]
+- [ ] [Step 3]
+
+## Validation and Acceptance
+
+[Commands to run. Expected outputs. Observable behavior that proves success.
+Phrase as: "running X produces Y".]
+
+## Key Decisions
+
+| Decision | Choice | Rationale |
+| -------- | ------ | --------- |
+| [decision] | [choice] | [why] |
+
+## Risks & Mitigations
+
+- **Risk:** [what could go wrong]
+  **Mitigation:** [how to handle it]
+
+## Surprises & Discoveries
+
+[None yet.]
+
+## Outcomes & Retrospective
+
+[To be written at completion.]'
+
+# ── build the prompt ─────────────────────────────────────────────────
+FULL_PROMPT="You are a senior software architect generating an implementation specification.
+Be specific: name files, functions, libraries. Prefer existing codebase patterns.
+Flag ambiguities rather than assuming. Keep it under 1000 words.
+Your output should be the raw spec markdown, nothing else.
+
+Generate an implementation spec following this skeleton format exactly:
+
+<spec-skeleton>
+${SKELETON}
+</spec-skeleton>
+
+<user-request>
+${PROMPT}
+</user-request>"
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+echo "$FULL_PROMPT" > "$TMPDIR/prompt.md"
+
+# ── models ───────────────────────────────────────────────────────────
+MODEL_A="claude-opus-4-6"
+MODEL_B="gpt-5.4"
+MODEL_C="gemini-3.1-pro-preview"
+LABEL_A="Opus 4.6"
+LABEL_B="GPT-5.4"
+LABEL_C="Gemini 3.1 Pro"
+
+# ── fire all three in parallel ───────────────────────────────────────
+droid exec -m "$MODEL_A" -r high -f "$TMPDIR/prompt.md" -o json 2>/dev/null > "$TMPDIR/a.json" &
+PID_A=$!
+droid exec -m "$MODEL_B" -r high -f "$TMPDIR/prompt.md" -o json 2>/dev/null > "$TMPDIR/b.json" &
+PID_B=$!
+droid exec -m "$MODEL_C" -r high -f "$TMPDIR/prompt.md" -o json 2>/dev/null > "$TMPDIR/c.json" &
+PID_C=$!
+
+FAIL=""
+wait $PID_A 2>/dev/null || FAIL="${FAIL}${LABEL_A} "
+wait $PID_B 2>/dev/null || FAIL="${FAIL}${LABEL_B} "
+wait $PID_C 2>/dev/null || FAIL="${FAIL}${LABEL_C} "
+
+# ── extract results ──────────────────────────────────────────────────
+extract() {
+  local file="$1"
+  if [ -s "$file" ]; then
+    jq -r '.result // empty' "$file" 2>/dev/null || cat "$file"
+  fi
+}
+
+RESULT_A=$(extract "$TMPDIR/a.json")
+RESULT_B=$(extract "$TMPDIR/b.json")
+RESULT_C=$(extract "$TMPDIR/c.json")
+
+# ── present results ──────────────────────────────────────────────────
+echo "=== RFSPEC RESULTS ==="
+echo ""
+echo "User request: ${PROMPT}"
+echo ""
+
+[ -n "$RESULT_A" ] && printf '### Option A -- %s\n\n%s\n\n' "$LABEL_A" "$RESULT_A"
+[ -n "$RESULT_B" ] && printf '### Option B -- %s\n\n%s\n\n' "$LABEL_B" "$RESULT_B"
+[ -n "$RESULT_C" ] && printf '### Option C -- %s\n\n%s\n\n' "$LABEL_C" "$RESULT_C"
+
+if [ -n "$FAIL" ]; then
+  echo "Note: The following models encountered errors: ${FAIL}"
+  echo ""
+fi
+
+SUCCESS=0
+[ -n "$RESULT_A" ] && SUCCESS=$((SUCCESS + 1))
+[ -n "$RESULT_B" ] && SUCCESS=$((SUCCESS + 1))
+[ -n "$RESULT_C" ] && SUCCESS=$((SUCCESS + 1))
+
+if [ "$SUCCESS" -eq 0 ]; then
+  echo "Error: All three models failed. Check that your droid CLI is authenticated"
+  echo "and the models (${MODEL_A}, ${MODEL_B}, ${MODEL_C}) are available."
+  exit 1
+fi
+
+echo "=== AGENT INSTRUCTIONS ==="
+echo "Analyze the specs above. Provide a brief comparison of each model's"
+echo "strengths and weaknesses. Then use the AskUser tool to offer:"
+echo "- Use Option A (${LABEL_A}) as-is"
+echo "- Use Option B (${LABEL_B}) as-is"
+echo "- Use Option C (${LABEL_C}) as-is"
+echo "- Synthesize a refined spec combining the best of all three"
+echo "- No -- none of these work (explain why)"
+echo "If the user picks synthesis, combine the strongest elements and save"
+echo "to specs/active/YYYY-MM-DD-<slug>.md. If rejected, gather feedback."


### PR DESCRIPTION
## What

Adds the **rfspec** plugin -- a `/rfspec` slash command that fans a prompt out to three models in parallel (Opus 4.6, GPT-5.4, Gemini 3.1 Pro) and presents the competing implementation specs side-by-side so the user can pick one or synthesize the best parts.

## Changes

- `plugins/rfspec/` -- new plugin directory
  - `.factory-plugin/plugin.json` -- manifest
  - `commands/rfspec` -- executable bash command with dependency guards, parallel `droid exec` calls, graceful per-model failure handling
  - `README.md` -- usage, requirements, spec skeleton docs
- `.factory-plugin/marketplace.json` -- added rfspec entry
- `README.md` -- added rfspec to Available Plugins section

## Requirements

- `droid` CLI (authenticated)
- `jq` for JSON parsing

The command degrades gracefully: if one or two models fail it still presents the successful results; it only errors if all three fail.