### PR TITLE
fix(review): show LGTM when review finds no issues

### DIFF
--- a/plugins/core/skills/review/SKILL.md
+++ b/plugins/core/skills/review/SKILL.md
@@ -248,4 +248,6 @@ Before approving a candidate:
 
 When invoked locally (TUI/CLI), analyze the changes and provide a structured summary of findings. List each finding with its priority, file, line, and description.
 
+If the review produces **no findings**, respond with a short **LGTM** message (e.g., "LGTM — no issues found."). Do not pad it with caveats or disclaimers.
+
 Do **not** post inline comments to the PR or submit a GitHub review unless the user explicitly asks for it.


### PR DESCRIPTION
## Description

Add an instruction to the review skill's Output section so the agent responds with a concise **LGTM** message instead of a generic reply when the code review produces no findings.

## How Has This Been Tested?

Reviewed the SKILL.md diff to verify correctness.