### PR TITLE
docs: add MIT license and contributing guidelines

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-or-improvement.md
+++ b/.github/ISSUE_TEMPLATE/bug-or-improvement.md
@@ -1,0 +1,21 @@
+---
+name: Bug or improvement
+about: Report an issue or suggest an improvement to an existing plugin
+labels: bug
+---
+
+## Which plugin and skill?
+
+<!-- e.g., droid-control / compose -->
+
+## What happened?
+
+<!-- What did you see? Include error messages or unexpected behavior. -->
+
+## What did you expect?
+
+<!-- What should have happened instead? -->
+
+## Steps to reproduce
+
+<!-- How can someone else see the same issue? -->

--- a/.github/ISSUE_TEMPLATE/skill-proposal.md
+++ b/.github/ISSUE_TEMPLATE/skill-proposal.md
@@ -1,0 +1,25 @@
+---
+name: Skill proposal
+about: Propose a new skill or command for an existing plugin
+labels: proposal
+---
+
+## Which plugin?
+
+<!-- e.g., droid-control, security-engineer, droid-evolved -->
+
+## What should the skill do?
+
+<!-- One or two sentences. What capability does this add? -->
+
+## Who benefits?
+
+<!-- What kind of user or workflow does this help? Is this broadly useful or specific to your setup? -->
+
+## Why does it belong here?
+
+<!-- Why should this live in this marketplace rather than a standalone plugin in your own repo? -->
+
+## Anything else?
+
+<!-- Links, examples, prior art, rough sketch of how it might work. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,51 @@
+# Contributing
+
+## What's open to contributions
+
+| Plugin | Who can contribute | Process |
+|--------|--------------------|---------|
+| `core` | Factory employees only | Internal review |
+| Everything else | Anyone | Open an issue first, then PR |
+
+## Before you start
+
+**Open an issue before writing code.** Describe what you want to change and why. This saves everyone time if the direction needs adjustment or the work is already planned.
+
+Small fixes (typos, broken links, clarifying a sentence) can go straight to a PR.
+
+## Standards
+
+**You must be willing to stand behind every line you push.** If you used AI tools to help write code, that's fine, but you are responsible for reviewing and understanding it. PRs with unreviewed generated output will be closed.
+
+**No promotions.** Plugins exist to give Droids useful capabilities, not to advertise products or services. Plugins that primarily serve to promote external software will be rejected.
+
+**Broadly useful.** This marketplace is for plugins that serve a wide range of users. If a plugin or feature only applies to a narrow workflow or a specific team's setup, it's better suited as a standalone plugin in your own repo. When proposing new plugins or significant additions, consider whether most Droid users would benefit.
+
+**Match existing conventions.** Read the plugin you're modifying before changing it. Follow the same file structure, naming, and style. When in doubt, look at how existing plugins handle it.
+
+## Submitting a PR
+
+1. Fork the repo and create a branch from `master`.
+2. Make your changes. Keep the diff focused on one thing.
+3. Test your changes locally by installing the plugin via the marketplace.
+4. Open a PR with a clear description of what changed and why.
+
+## Plugin structure
+
+Every plugin must include a `.factory-plugin/plugin.json` manifest. See the [Factory plugin docs](https://docs.factory.ai/cli/configuration/plugins) for the full spec.
+
+```
+my-plugin/
+├── .factory-plugin/
+│   └── plugin.json
+├── skills/
+│   └── my-skill/
+│       └── SKILL.md
+├── commands/
+│   └── my-command.md
+└── README.md
+```
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the [MIT License](LICENSE).

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Factory AI, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Description

Adds repo-wide license and contribution guidelines.

- **LICENSE**: MIT, copyright Factory AI, Inc.
- **CONTRIBUTING.md**: core plugin is Factory-employees only; all other plugins open to external contributions with issue-first process. Standards: stand behind your code, no promotions, match existing conventions.