### PR TITLE
fix(droid-control): repair YAML frontmatter of command files

### DIFF
--- a/plugins/droid-control/commands/demo.md
+++ b/plugins/droid-control/commands/demo.md
@@ -1,6 +1,6 @@
 ---
 description: Plan and record a demo video of a feature or PR
-argument-hint: "<PR-number> [-- notes]" or "<description of what to demo>"
+argument-hint: '"<PR-number> [-- notes]" or "<description of what to demo>"'
 ---
 
 Load skills: **droid-control**.

--- a/plugins/droid-control/commands/qa-test.md
+++ b/plugins/droid-control/commands/qa-test.md
@@ -1,6 +1,6 @@
 ---
 description: Run an automated QA test flow against a terminal CLI or web/Electron app
-argument-hint: "<URL>" or "<app-name>" or "<PR-number> [-- focus area]" or "<description>"
+argument-hint: '"<URL>" or "<app-name>" or "<PR-number> [-- focus area]" or "<description>"'
 ---
 
 Load skills: **droid-control**.

--- a/plugins/droid-control/commands/verify.md
+++ b/plugins/droid-control/commands/verify.md
@@ -1,6 +1,6 @@
 ---
 description: Test a claim about behavior and report whether the evidence supports or refutes it
-argument-hint: "<claim to test>" or "<PR-number> -- <specific claim>"
+argument-hint: '"<claim to test>" or "<PR-number> -- <specific claim>"'
 ---
 
 Load skills: **droid-control**.


### PR DESCRIPTION
## Description

The `argument-hint` field in each of the three droid-control command files (`demo.md`, `qa-test.md`, `verify.md`) was written as a bare YAML value containing multiple double-quoted tokens joined by `or`, e.g. `argument-hint: "<URL>" or "<app-name>" or ...`. YAML parses the first `"..."` as a complete flow scalar, then errors on the trailing tokens, so the frontmatter was invalid for any strict YAML reader. This wraps each full value in single quotes, producing a valid single YAML string while preserving the intended literal (double-quoted placeholder tokens separated by `or`) that users see in the argument hint.

## Related Issue

N/A -- no ticket.

## Potential Risk & Impact

Low risk. Change is confined to frontmatter of three command-definition markdown files; no runtime code, no exported APIs, no schema shared with other plugins. The parsed `argument-hint` value is unchanged character-for-character from the authors' original intent -- only the outer quoting style differs, so any UI rendering the hint sees the same string.

## How Has This Been Tested?

- Parsed each file's frontmatter with PyYAML before and after the change: before -> `YAML ERROR: expected <block end>, but found '<scalar>'` on all three; after -> clean parse with `argument-hint` equal to the original human-readable string in every case.
- `git diff --stat` confirms the PR is a strict 3-line change across 3 files, nothing else touched.

<details>
<summary>Root Cause Analysis</summary>

**How the bug was traced**: Ran `yaml.safe_load` on the frontmatter block extracted from each of `plugins/droid-control/commands/{demo,qa-test,verify}.md`. All three raised `expected <block end>, but found '<scalar>'` pointing at the column of the second opening `"` in `argument-hint`. The root cause is the YAML flow-scalar rule: a value that starts with `"` terminates at the next unescaped `"`, so `"<URL>" or "<app-name>"` is seen as scalar `<URL>` followed by invalid trailing content `or "<app-name>"`.

**How root cause drove the fix**: The intended display value is a single human-readable string that happens to contain double quotes. The idiomatic YAML way to express that is a single-quoted scalar wrapping the whole thing, which lets the inner `"` characters pass through verbatim. That is a one-character change per line (open and close) and keeps the rendered argument hint identical, so it fixes the parse error without altering semantics or requiring downstream consumers to change.

</details>
