### PR TITLE
feat(atomic-chat): add Factory plugin for local Atomic Chat LLM

### DIFF
--- a/.factory-plugin/marketplace.json
+++ b/.factory-plugin/marketplace.json
@@ -53,6 +53,12 @@
       "description": "Pull request lifecycle skills: create PRs with consistent conventions and follow up on them until merge-ready",
       "source": "./plugins/code-review",
       "category": "productivity"
+    },
+    {
+      "name": "atomic-chat",
+      "description": "Connect Atomic Chat local LLMs to Factory via OpenAI-compatible API and setup skills",
+      "source": "./plugins/atomic-chat",
+      "category": "integrations"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -98,6 +98,16 @@ Skills for continuous learning and improvement.
 
 Autonomous experiment loop for optimization research. Try an idea, measure it, keep what works, discard what doesn't, repeat. Works standalone or as a mission worker.
 
+### atomic-chat
+
+Connect [Atomic Chat](https://atomic.chat) local LLMs to Factory via OpenAI-compatible API (`http://127.0.0.1:1337/v1`).
+
+**Commands:** `/atomic-chat-setup`
+
+**Skills:** `atomic-chat-setup` — configure `customModels` in `~/.factory/settings.json`, verify `/v1/models`, troubleshoot Docker networking
+
+See [plugins/atomic-chat/README.md](plugins/atomic-chat/README.md) for details.
+
 ## Plugin Structure
 
 Each plugin follows the Factory plugin format:

--- a/plugins/atomic-chat/.factory-plugin/plugin.json
+++ b/plugins/atomic-chat/.factory-plugin/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "atomic-chat",
+  "description": "Use Atomic Chat local LLMs with Factory via OpenAI-compatible API and setup skills",
+  "version": "1.0.0",
+  "author": {
+    "name": "yanalialiuk",
+    "email": "ylialuke@gmail.com"
+  },
+  "homepage": "https://atomic.chat",
+  "repository": "https://github.com/AtomicBot-ai/Atomic-Chat",
+  "license": "MIT"
+}

--- a/plugins/atomic-chat/README.md
+++ b/plugins/atomic-chat/README.md
@@ -1,0 +1,56 @@
+# atomic-chat
+
+Connect [Atomic Chat](https://atomic.chat) to Factory Droid as a **local OpenAI-compatible** model provider.
+
+Atomic Chat runs open-weight models on your machine with a local API at `http://127.0.0.1:1337/v1`. Optional Exa web search runs inside the Atomic Chat app (not this plugin).
+
+## Install
+
+```bash
+droid plugin marketplace add https://github.com/Factory-AI/factory-plugins
+droid plugin install atomic-chat@factory-plugins --scope user
+```
+
+Or browse via `/plugins` → **atomic-chat**.
+
+## Quick setup
+
+Run in a Droid session:
+
+```text
+/atomic-chat-setup
+```
+
+Or ask Droid to load the **atomic-chat-setup** skill and configure `~/.factory/settings.json`.
+
+## Manual configuration
+
+Add to `~/.factory/settings.json`:
+
+```json
+{
+  "customModels": [
+    {
+      "model": "YOUR_MODEL_ID",
+      "displayName": "Local model [Atomic Chat]",
+      "baseUrl": "http://127.0.0.1:1337/v1",
+      "apiKey": "atomic-chat-local",
+      "provider": "generic-chat-completion-api",
+      "maxOutputTokens": 16000
+    }
+  ]
+}
+```
+
+Replace `YOUR_MODEL_ID` with an id from `curl http://127.0.0.1:1337/v1/models`.
+
+## Prerequisites
+
+1. Install [Atomic Chat](https://atomic.chat) and download at least one model
+2. Enable **Settings → Local API Server** (default port `1337`)
+3. Verify: `curl http://127.0.0.1:1337/v1/models`
+
+## Links
+
+- [Atomic Chat](https://atomic.chat)
+- [GitHub](https://github.com/AtomicBot-ai/Atomic-Chat)

--- a/plugins/atomic-chat/commands/atomic-chat-setup.md
+++ b/plugins/atomic-chat/commands/atomic-chat-setup.md
@@ -1,0 +1,19 @@
+---
+description: Configure Factory to use Atomic Chat local models (OpenAI-compatible API at :1337)
+argument-hint: '[optional model id from Atomic Chat]'
+---
+
+Load skill: **atomic-chat-setup**.
+
+## Goal
+
+Wire Factory `customModels` to the user's Atomic Chat Local API Server.
+
+## Steps
+
+1. If `$ARGUMENTS` contains a model id, use it. Otherwise call `GET http://127.0.0.1:1337/v1/models` and pick the best match (or ask the user).
+2. Follow **atomic-chat-setup** to update `~/.factory/settings.json` without clobbering unrelated `customModels` entries.
+3. Run the chat completions smoke test from the skill.
+4. Report: model id, base URL, display name, and how to select it in Droid.
+
+If Atomic Chat is not running, give install/enable steps from the skill and stop — do not invent API keys or model names.

--- a/plugins/atomic-chat/skills/atomic-chat-setup/SKILL.md
+++ b/plugins/atomic-chat/skills/atomic-chat-setup/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: atomic-chat-setup
+version: 1.0.0
+description: |
+  Configure Factory Droid to use Atomic Chat as a local LLM provider (OpenAI-compatible API).
+  Use when the user wants to:
+  - Run Droid with local models via Atomic Chat
+  - Set up BYOK customModels for http://127.0.0.1:1337/v1
+  - Troubleshoot Atomic Chat + Factory connectivity
+  - Pick a model id from Atomic Chat's /v1/models endpoint
+disable-model-invocation: false
+---
+
+# Atomic Chat + Factory setup
+
+Atomic Chat exposes an OpenAI-compatible API (default `http://127.0.0.1:1337/v1`). Factory loads custom providers from `~/.factory/settings.json` → `customModels`.
+
+## 1. Verify Atomic Chat is running
+
+```bash
+curl -s http://127.0.0.1:1337/v1/models | head -c 2000
+```
+
+If this fails:
+
+1. Open Atomic Chat → **Settings → Local API Server** → enable (port `1337`)
+2. Download at least one model in the app
+3. Retry the curl command
+
+## 2. Pick a model id
+
+From the JSON response, use a model `id` string (e.g. from `data[].id`). If multiple models exist, prefer one the user already loaded; otherwise list options and ask.
+
+## 3. Update Factory settings
+
+Edit `~/.factory/settings.json`. Merge into `customModels` (do not remove existing entries unless the user asks):
+
+```json
+{
+  "customModels": [
+    {
+      "model": "<MODEL_ID>",
+      "displayName": "<MODEL_ID> [Atomic Chat]",
+      "baseUrl": "http://127.0.0.1:1337/v1",
+      "apiKey": "atomic-chat-local",
+      "provider": "generic-chat-completion-api",
+      "maxOutputTokens": 16000
+    }
+  ]
+}
+```
+
+Notes:
+
+- `apiKey` can be any non-empty string for default local installs; Atomic Chat is keyless by default
+- Use `maxOutputTokens` appropriate for the model context window when known
+- Preserve valid JSON; back up the file before editing if it already has content
+
+## 4. Docker / remote Factory
+
+If Droid runs in Docker and Atomic Chat on the host:
+
+- macOS/Windows Docker Desktop: `http://host.docker.internal:1337/v1`
+- Linux: host LAN IP instead of `127.0.0.1`
+
+## 5. Verify end-to-end
+
+```bash
+curl -s http://127.0.0.1:1337/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer atomic-chat-local" \
+  -d '{"model":"<MODEL_ID>","messages":[{"role":"user","content":"ping"}],"max_tokens":16}'
+```
+
+Tell the user to restart or start a new Droid session, then select the new **displayName** in the model picker.
+
+## Troubleshooting
+
+| Issue | Fix |
+|-------|-----|
+| Connection refused on 1337 | Enable Local API Server in Atomic Chat |
+| Model not in list | Download model in Atomic Chat first |
+| Empty completions | Check model id matches `/v1/models` exactly |
+| Factory can't reach host | Use `host.docker.internal` from containers |
+
+## References
+
+- Product: https://atomic.chat
+- Source: https://github.com/AtomicBot-ai/Atomic-Chat
+- Factory BYOK pattern matches [Ollama local setup](https://docs.factory.ai/cli/byok/ollama) with a different `baseUrl`


### PR DESCRIPTION
## Summary

Adds **atomic-chat** to the official Factory plugins marketplace — connect [Atomic Chat](https://atomic.chat) local models to Droid via Factory's `customModels` BYOK path (`generic-chat-completion-api` → `http://127.0.0.1:1337/v1`).

## What's included

- `plugins/atomic-chat/` marketplace entry (`integrations` category)
- Skill **`atomic-chat-setup`** — verify Local API Server, pick model from `/v1/models`, merge `~/.factory/settings.json`
- Command **`/atomic-chat-setup`** — guided wiring + smoke test
- README with manual `customModels` JSON (same pattern as [Ollama BYOK](https://docs.factory.ai/cli/byok/ollama))

## Usage after merge

```bash
droid plugin marketplace add https://github.com/Factory-AI/factory-plugins
droid plugin install atomic-chat@factory-plugins --scope user
```

Then in Droid: `/atomic-chat-setup`

## Test plan

- [ ] `droid plugin install atomic-chat@factory-plugins` from marketplace manifest
- [ ] `/atomic-chat-setup` loads skill and documents `customModels` merge
- [ ] With Atomic Chat running on :1337, smoke `curl /v1/models` steps succeed
- [ ] Existing marketplace plugins unchanged
