### PR TITLE
fix(droid-control): align top row of ASCII DROID wordmark (MB-19)

### DIFF
--- a/plugins/droid-control/remotion/src/components/DroidWordmark.tsx
+++ b/plugins/droid-control/remotion/src/components/DroidWordmark.tsx
@@ -9,7 +9,7 @@ const DROID_ASCII = `
   ███    ███    ███ ███       ███    ███    ███    ███    ███
   ███    ███    ███  ███      ███    ███    ███    ███    ███
   ██████████    ███   ███     ██████████    ███    ██████████
-`.trim();
+`.replace(/^\n/, '').trimEnd();
 
 export const DroidWordmark: React.FC<{
   palette: Palette;


### PR DESCRIPTION
## Description

**What**

In the showcase outro, the top row of the ASCII DROID wordmark renders two columns left of the rows below, so the top bar of every letter overhangs the letter body.

**Why**

`DROID_ASCII` is an indented template literal closed with `.trim()`, which strips the leading newline *and* the first row's two-space indent. Rows 2-7 keep their indent, and `whiteSpace: 'pre'` renders the mismatch verbatim.

**How**

Replace `.trim()` with `.replace(/^\n/, '').trimEnd()`, which drops only the leading newline and trailing whitespace while preserving the first row's indent.

## Visual Evidence

Outro still rendered from this branch (`--frame=480 --props='{"clipDuration":10}'`): the top row of each letter now aligns with the letter body.

![Fixed ASCII DROID wordmark](https://github.com/user-attachments/assets/f6ff63fe-0c44-4f58-8364-ff8893f6b4ee)

## Repro Recipe

```bash
cd plugins/droid-control/remotion
npx remotion still src/index.ts Showcase out/wordmark.png --frame=480 --props='{"clipDuration":10}'
```

Open `out/wordmark.png` (the final outro frame with the wordmark fully faded in). On `master` the top row of each letter sits two columns left of the letter body; on this branch it aligns. The explicit `clipDuration` prop is required because the default-props duration math (10s clip fallback in `lib/duration.ts`) and the component's 60s fallback disagree, which pushes the outro past the end of the composition; that mismatch predates this PR.

## Related Issue

Closes MB-19

## Reviewer Guide

**Diff shape**: 100% `DroidWordmark.tsx`, one expression.
**Review depth**: Skim — single-line fix with the cause spelled out in the commit body.
**Read order**:
1. `plugins/droid-control/remotion/src/components/DroidWordmark.tsx:10` — the template-literal terminator is the whole change.

## Risk & Impact

Low risk — isolated to the outro wordmark string. No timing, layout, or API changes beyond the restored indent.

## Verification

**Behavior verified.** Outro still rendered from this branch shows the top row aligned with the letter bodies (screenshot attached above) verified @ 5e5b618.
**Regression coverage.** N/A — pure string-literal fix; no test harness exists in the remotion package (no jest/vitest config).
**Not tested.** Full Showcase video render (still capture covers the changed surface; the wordmark is static once faded in).
**Standard validators.** typecheck (`tsc --noEmit`) and slop-scan delta clean; no format/lint/test tooling configured in this repo.