### PR TITLE
feat: add screenpipe workflow-memory plugin

### DIFF
--- a/.factory-plugin/marketplace.json
+++ b/.factory-plugin/marketplace.json
@@ -53,6 +53,12 @@
       "description": "Pull request lifecycle skills: create PRs with consistent conventions and follow up on them until merge-ready",
       "source": "./plugins/code-review",
       "category": "productivity"
+    },
+    {
+      "name": "screenpipe",
+      "description": "Local-first workflow memory for reconstructing real work, drafting cited SOPs, and finding automation candidates",
+      "source": "./plugins/screenpipe",
+      "category": "productivity"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -71,6 +71,18 @@ Inspect runtime behavior: HTTP interception, traffic capture, and wire-level deb
 
 - `http-toolkit-intercept` - Intercept and debug HTTP traffic from any CLI, service, or script via HTTP Toolkit (language/runtime agnostic)
 
+### screenpipe
+
+Local-first workflow memory for Droids. Search private screen and audio history,
+reconstruct multi-app work from timestamped evidence, draft cited SOPs, and
+identify automation candidates.
+
+**Skills:**
+
+- `screenpipe` - Query screenpipe carefully and turn real work evidence into traceable workflows and SOPs
+
+**MCP:** `npx -y screenpipe-mcp@0.19.1`
+
 ### code-review
 
 Pull request lifecycle skills: open, triage, and follow up on PRs with consistent conventions.

--- a/plugins/screenpipe/.factory-plugin/plugin.json
+++ b/plugins/screenpipe/.factory-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "screenpipe",
+  "description": "Local-first workflow memory for reconstructing real work, drafting cited SOPs, and finding automation candidates",
+  "version": "1.0.0",
+  "author": {
+    "name": "screenpipe",
+    "url": "https://screenpi.pe"
+  },
+  "license": "MIT"
+}

--- a/plugins/screenpipe/LICENSE
+++ b/plugins/screenpipe/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 screenpipe
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/screenpipe/README.md
+++ b/plugins/screenpipe/README.md
@@ -1,0 +1,27 @@
+# screenpipe for Factory Droid
+
+Use screenpipe as a local-first evidence layer for questions about real work.
+The plugin combines the pinned screenpipe MCP server with a skill for searching
+private work history, reconstructing repeated tasks, drafting cited SOPs, and
+identifying automation candidates.
+
+## Requirements
+
+- screenpipe installed and running locally
+- Node.js 18 or newer
+
+The MCP server discovers the local screenpipe API key from the installed app.
+This plugin disables the MCP package's outbound usage and error telemetry.
+
+Screen and audio history remains in the user's screenpipe instance. Evidence
+retrieved for a task enters the configured Droid model context. The skill treats
+retrieval as the default and requires explicit user intent before mutations.
+
+## Install
+
+```bash
+droid plugin install screenpipe@factory-plugins --scope user
+```
+
+Plugin wrapper files are MIT licensed. The screenpipe application and
+`screenpipe-mcp` package retain their respective upstream licenses.

--- a/plugins/screenpipe/mcp.json
+++ b/plugins/screenpipe/mcp.json
@@ -1,0 +1,16 @@
+{
+  "mcpServers": {
+    "screenpipe": {
+      "type": "stdio",
+      "command": "npx",
+      "args": [
+        "-y",
+        "screenpipe-mcp@0.19.1"
+      ],
+      "env": {
+        "SCREENPIPE_MCP_CLIENT": "factory-droid",
+        "SCREENPIPE_DISABLE_TELEMETRY": "1"
+      }
+    }
+  }
+}

--- a/plugins/screenpipe/skills/screenpipe/SKILL.md
+++ b/plugins/screenpipe/skills/screenpipe/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: screenpipe
+description: Use screenpipe's private local work history to recall prior activity, find decisions and meetings, reconstruct repeated workflows, draft evidence-backed SOPs, and identify automation candidates.
+---
+
+# screenpipe workflow memory
+
+Use the screenpipe MCP tools as the evidence layer for questions about the
+user's real work. Tool names may be prefixed by Droid; match them by the base
+names below.
+
+## Choose the smallest useful query
+
+1. Use `activity-summary` for broad questions about a period, app usage, or what the user was doing.
+2. Use `search-content` for specific text, conversations, people, projects, decisions, or audio. Filter by time and app when possible.
+3. Use `keyword-search` for fast exact-text lookup.
+4. Use `frame-context` or `get-frame-elements` only after a search result identifies a relevant frame.
+5. Use `list-meetings` and `get-meeting` for meeting history.
+
+Run `health-check` when screenpipe appears unavailable. Explain the failure
+clearly instead of inventing results.
+
+## Runtime and permissions
+
+This plugin launches `screenpipe-mcp@0.19.1` over stdio. The server advertises
+retrieval tools and mutation tools for memories, meetings, recording, speakers,
+notifications, and scheduled pipes. Treat retrieval as the default; use a
+mutation tool only when the user explicitly requests that change.
+
+The MCP authenticates only to the user's local screenpipe API and discovers its
+key from the installed app. This plugin sets `SCREENPIPE_DISABLE_TELEMETRY=1`,
+disabling the MCP package's outbound usage and error telemetry. Retrieved
+content still enters the current Droid model context, so disclose that boundary
+when the configured model is remote.
+
+## Answer from evidence
+
+- Preserve timestamps, app names, window titles, speakers, and source identifiers returned by tools.
+- Distinguish direct evidence from inference.
+- Cite the moments that support conclusions. Never fabricate a frame ID, timestamp, quote, or deep link.
+- Prefer one well-filtered query over dumping long unfiltered history into context.
+- Treat absence of results as absence of evidence, not proof that something did not happen.
+
+## Reconstruct a workflow
+
+1. Define the task, actor, time range, and intended output.
+2. Retrieve a broad activity summary for the period.
+3. Search the relevant apps, windows, meetings, and terms.
+4. Order the evidence into trigger, inputs, actions, decisions, handoffs, and output.
+5. Mark gaps and uncertainty explicitly.
+6. Return a concise workflow report with cited moments and repeated patterns.
+
+## Draft an SOP or automation candidate
+
+- Build the SOP from repeated observed runs, not a single anecdote.
+- Include prerequisites, ordered steps, decision points, exceptions, validation, and completion evidence.
+- Separate stable steps from case-specific details.
+- Identify automation candidates only after the workflow is evidenced.
+- Recommend a human review point before any irreversible or externally visible action.
+
+## Privacy and mutations
+
+Screenpipe data can contain private messages, customer information,
+credentials, and other sensitive material.
+
+- Do not share, upload, or quote sensitive history outside the current task without explicit user approval.
+- Do not export video, change recording, edit memories, modify meetings or speakers, run pipes, or send notifications unless the user requested that action.
+- Keep retrieval local when possible and disclose when a remote model will receive retrieved context.

--- a/skills/screenpipe
+++ b/skills/screenpipe
@@ -1,0 +1,1 @@
+../plugins/screenpipe/skills/screenpipe


### PR DESCRIPTION
## Summary
- add a screenpipe plugin with its MCP server and evidence-first workflow skill
- expose the skill through the repository's top-level skill index
- document local prerequisites, privacy boundaries, and mutation guardrails

## Runtime
- pins `screenpipe-mcp@0.19.1`
- disables package usage and error telemetry
- requires screenpipe desktop and Node.js 18+

## Validation
- parsed all plugin and marketplace JSON
- verified the skill index entry is Git mode `120000`
- `git diff --check`