### PR TITLE
fix(droid-control): support tctl on Windows

### DIFF
--- a/plugins/droid-control/bin/tctl
+++ b/plugins/droid-control/bin/tctl
@@ -584,6 +584,20 @@ launch_tuistory() {
     cleanup_tuistory_asciinema "$session" "$record_path"
     launch_cmd="$(write_tuistory_recording_runner "$session" "$record_path")"
   fi
+  # On Windows, passing a .sh file directly makes CreateProcess follow the
+  # file association and open Git Bash/Mintty outside Tuistory's PTY. Launch
+  # the runner through bash.exe instead. Tuistory's Windows command parser
+  # does not preserve quoted executable paths, so use DOS short paths to keep
+  # both argv entries whitespace-free.
+  case "$(uname -s)" in
+    MINGW*|MSYS*|CYGWIN*)
+      require_cmd cygpath
+      local bash_win runner_win
+      bash_win="$(cygpath -w -s "$(command -v bash)")"
+      runner_win="$(cygpath -w -s "$launch_cmd")"
+      launch_cmd="$bash_win $runner_win"
+      ;;
+  esac
   local args=(launch "$launch_cmd" -s "$session" --cols "$cols" --rows "$rows")
   tuistory "${args[@]}"
 }


### PR DESCRIPTION
## Description

On Windows, `tctl` passed its generated `.sh` runner directly to Tuistory. Windows followed the shell script file association and opened Git Bash/Mintty outside Tuistory's PTY, leaving Droid Control with blank output and orphaned terminal windows.

Windows MSYS environments now launch the generated runner explicitly through `bash.exe`. Both executable paths use DOS short paths because Tuistory's Windows command parser does not preserve quoted executable paths containing spaces. Linux and macOS behavior is unchanged.

## Potential Risk & Impact

- The new path only runs under MINGW, MSYS, and Cygwin.
- Windows execution now requires `cygpath`, which ships with the Git Bash environment already required to run `tctl`.
- Tuistory recording uses the same explicit Bash runner path.

## How Has This Been Tested?

- `bash -n plugins/droid-control/bin/tctl`
- Windows non-interactive smoke test through the cloned `tctl`: captured `TCTL_ECHO_OK`
- Windows interactive smoke test through the cloned `tctl`: typed a PowerShell command and captured `TCTL_INTERACTIVE_OK`
- Confirmed the fixed wrapper no longer leaves test-related Git Bash, Mintty, shell, or Bun processes running
